### PR TITLE
startxfce4: mark .desktop links in Desktop as safe

### DIFF
--- a/startxfce4.bash
+++ b/startxfce4.bash
@@ -16,5 +16,10 @@ cp -af /usr/share/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml \
   /usr/share/xfce4/xfconf/xfce-perchannel-xml/xfce4-screensaver.xml \
   $HOME/.config/xfce4/xfconf/xfce-perchannel-xml/
 
+# mark shortcuts on the desktop as trusted to execute
+for f in ~/Desktop/*.desktop; do
+  gio set -t string "$f" metadata::xfce-exe-checksum "$(sha256sum "$f" | cut -d" " -f1)"
+done
+
 # start window manager
 [ -n "$STARTXFCE4" ] && exec "$STARTXFCE4"


### PR DESCRIPTION
The XFCE version in EL9 introduced that .desktop files outside of `/usr/share` etc. (XDG_DATA_DIRS) need to be acknowledged by the user as safe before running. Their SHA256 needs to be written to a GVFS metadata value.

(This could also go to the entrypoint.sh but then needs to be run as the container user.)